### PR TITLE
Prepare dart code for publishing in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,9 +74,9 @@ steps:
     echo "environment:" >> pubspec.yaml 
     echo "  sdk: '>=2.0.0 <3.0.0'" >> pubspec.yaml 
     mv docs doc
-    pub publish
+    tar -czf dart.tar.gz *
     cd ../..
-  displayName: 'pub publish'
+  displayName: 'create dart archive'
 
 # Install tools required to convert markdown to PDF
 - script: |
@@ -112,3 +112,4 @@ steps:
     assets: |
         $(Build.Repository.LocalPath)/ARCHITECTURE.pdf
         $(Build.Repository.LocalPath)/generated/spring/spring.tar.gz
+        $(Build.Repository.LocalPath)/generated/dart/dart.tar.gz

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,13 +28,22 @@ steps:
 # install the swagger-codegen, generate the java spring code and archive it, generate the dart code and publish it to pub
 - script: |
     wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.8/swagger-codegen-cli-2.4.8.jar -O swagger-codegen-cli.jar
+  displayName: 'Swagger Codegen install'
+# show code generation options
+- script: |
     echo "Java Options"
     java -jar swagger-codegen-cli.jar config-help -l spring
     echo "dart options"
     java -jar swagger-codegen-cli.jar config-help -l dart
+  displayName: 'Show Swagger Codegen options'
+# create directories for generated code
+- script: |
     mkdir generated/
     mkdir generated/spring/
     mkdir generated/dart/
+  displayName: 'create directories for generated code'
+# generate java spring code
+- script: |
     java -jar swagger-codegen-cli.jar generate \
       -i api/swagger.json \
       -l spring \
@@ -42,6 +51,10 @@ steps:
     cd generated/spring/
     tar -czf spring.tar.gz *
     cd ../..
+  displayName: 'spring Swagger Codegen '
+  
+# generate dart client code and publish to pub
+- script: |
     java -jar swagger-codegen-cli.jar generate \
       -i api/swagger.json \
       -l dart \
@@ -51,18 +64,14 @@ steps:
     export PATH="$PATH":"$HOME/.pub-cache/bin"
     export PATH="$PATH":/usr/lib/dart/bin/
     wget -O LICENSE https://spdx.org/licenses/LGPL-2.0-only.html#licenseText
-    echo "### printing pubspec###"
-    cat pubspec.yaml
     echo "authors:" >> pubspec.yaml
     echo "  - Benjamin Schilling <benjamin.a.schilling@freenet.de>" >> pubspec.yaml 
     echo "homepage: https://github.com/openrqm/openrqm-docs " >> pubspec.yaml 
     echo "environment:" >> pubspec.yaml 
     echo "  sdk: '>=2.0.0 <3.0.0'" >> pubspec.yaml 
-    echo "### printing pubspec###"
-    cat pubspec.yaml
     pub publish --dry-run
     cd ../..
-  displayName: 'Swagger Codegen & publish'
+  displayName: 'dart Swagger Codegen & publish'
 
 # Install tools required to convert markdown to PDF
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,11 @@ steps:
     export PATH="$PATH":"$HOME/.pub-cache/bin"
     export PATH="$PATH":/usr/lib/dart/bin/
     wget -O LICENSE https://spdx.org/licenses/LGPL-2.0-only.html#licenseText
+    echo "authors: \
+        - Benjamin Schilling <benjamin.a.schilling@freenet.de> \
+        homepage: https://github.com/openrqm/openrqm-docs \
+        environment: \
+          sdk: '>=2.0.0 <3.0.0'" >> pubspec.yml 
     pub publish --dry-run
     cd ../..
   displayName: 'Swagger Codegen & publish'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,10 @@ steps:
       -l dart \
       -o generated/dart/ \
       -c api/dart-config.json
+  displayName: 'dart Swagger Codegen'
+
+# publish dart code to pub
+- script: |
     cd generated/dart/
     export PATH="$PATH":"$HOME/.pub-cache/bin"
     export PATH="$PATH":/usr/lib/dart/bin/
@@ -69,9 +73,10 @@ steps:
     echo "homepage: https://github.com/openrqm/openrqm-docs " >> pubspec.yaml 
     echo "environment:" >> pubspec.yaml 
     echo "  sdk: '>=2.0.0 <3.0.0'" >> pubspec.yaml 
+    mv -r docs doc
     pub publish --dry-run
     cd ../..
-  displayName: 'dart Swagger Codegen & publish'
+  displayName: 'pub publish'
 
 # Install tools required to convert markdown to PDF
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ steps:
     echo "environment:" >> pubspec.yaml 
     echo "  sdk: '>=2.0.0 <3.0.0'" >> pubspec.yaml 
     mv docs doc
-    pub publish --dry-run
+    pub publish
     cd ../..
   displayName: 'pub publish'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,11 +51,14 @@ steps:
     export PATH="$PATH":"$HOME/.pub-cache/bin"
     export PATH="$PATH":/usr/lib/dart/bin/
     wget -O LICENSE https://spdx.org/licenses/LGPL-2.0-only.html#licenseText
-    echo "authors: \
-        - Benjamin Schilling <benjamin.a.schilling@freenet.de> \
-        homepage: https://github.com/openrqm/openrqm-docs \
-        environment: \
-          sdk: '>=2.0.0 <3.0.0'" >> pubspec.yml 
+    echo "### printing pubspec###"
+    cat pubspec.yml
+    echo "authors: Benjamin Schilling <benjamin.a.schilling@freenet.de>" >> pubspec.yml 
+    echo "homepage: https://github.com/openrqm/openrqm-docs " >> pubspec.yml 
+    echo "environment:" >> pubspec.yml 
+    echo "  sdk: \'>=2.0.0 <3.0.0\'" >> pubspec.yml 
+    echo "### printing pubspec###"
+    cat pubspec.yml
     pub publish --dry-run
     cd ../..
   displayName: 'Swagger Codegen & publish'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,13 +52,13 @@ steps:
     export PATH="$PATH":/usr/lib/dart/bin/
     wget -O LICENSE https://spdx.org/licenses/LGPL-2.0-only.html#licenseText
     echo "### printing pubspec###"
-    cat pubspec.yml
-    echo "authors: Benjamin Schilling <benjamin.a.schilling@freenet.de>" >> pubspec.yml 
-    echo "homepage: https://github.com/openrqm/openrqm-docs " >> pubspec.yml 
-    echo "environment:" >> pubspec.yml 
-    echo "  sdk: \'>=2.0.0 <3.0.0\'" >> pubspec.yml 
+    cat pubspec.yaml
+    echo "authors: Benjamin Schilling <benjamin.a.schilling@freenet.de>" >> pubspec.yaml 
+    echo "homepage: https://github.com/openrqm/openrqm-docs " >> pubspec.yaml 
+    echo "environment:" >> pubspec.yaml 
+    echo "  sdk: '>=2.0.0 <3.0.0'" >> pubspec.yaml 
     echo "### printing pubspec###"
-    cat pubspec.yml
+    cat pubspec.yaml
     pub publish --dry-run
     cd ../..
   displayName: 'Swagger Codegen & publish'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ steps:
     echo "homepage: https://github.com/openrqm/openrqm-docs " >> pubspec.yaml 
     echo "environment:" >> pubspec.yaml 
     echo "  sdk: '>=2.0.0 <3.0.0'" >> pubspec.yaml 
-    mv -r docs doc
+    mv docs doc
     pub publish --dry-run
     cd ../..
   displayName: 'pub publish'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,8 @@ steps:
     wget -O LICENSE https://spdx.org/licenses/LGPL-2.0-only.html#licenseText
     echo "### printing pubspec###"
     cat pubspec.yaml
-    echo "authors: Benjamin Schilling <benjamin.a.schilling@freenet.de>" >> pubspec.yaml 
+    echo "authors:" >> pubspec.yaml
+    echo "  - Benjamin Schilling <benjamin.a.schilling@freenet.de>" >> pubspec.yaml 
     echo "homepage: https://github.com/openrqm/openrqm-docs " >> pubspec.yaml 
     echo "environment:" >> pubspec.yaml 
     echo "  sdk: '>=2.0.0 <3.0.0'" >> pubspec.yaml 


### PR DESCRIPTION
Update azure pipeline for pub publishing, not publishing by CI due to timeouts, generates archive which can be published manually